### PR TITLE
Improve formatting and grammar of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,91 @@
 <img src="https://github.com/hchbaw/opp.zsh/raw/readme/ciw.png" />
 
-<pre>
-vim's text-objects-ish for zsh.
+Vim’s text-objects-ish for Zsh.
 
-Author: Takeshi Banse &lt;takebi@laafc.net&gt;
-License: Public Domain
+<dl>
+<dt>Author:</dt><dd>Takeshi Banse &lt;<a href="mailto:takebi@laafc.net">takebi@laafc.net</a>&gt;</dd>
+<dt>License:</dt><dd>Public Domain</dd>
+</dl>
 
 Thank you very much, Bram Moolenaar!
-I want to use the vim's text-objects in zsh.
+
+I want to use Vim’s text-objects in Zsh.
 
 To use this,
-1) source this file.
-% source opp.zsh
-2) If you wish to load the extensions, source them afterward.
-% source opp/*.zsh
-*Optionally* you can use the zcompiled file with the autoloading for a
-little faster loading on every shell start up, if you zcompile the
-necessary functions.
-*1) Prepare zcompiling the defined functions and the install command.
-% OS=(~/path/to/opp.zsh/{opp.zsh,opp/*.zsh})
-*2) If you have some opp/surround.zsh's configurations, those
-configurations could be zcompiled at this point. Assuming you have such a
-configuration file in ~/.zsh/opp-surround.zsh, you could do this.
-% OS=(~/path/to/opp.zsh/{opp.zsh,opp/*.zsh} ~/.zsh/opp-surround.zsh(N))
-*3) Generate the ~/.zsh/zfunc/{opp,opp-install}.zwc.
-% (zsh -c "for O in $OS;do . $O;done && opp-zcompile $OS[1] ~/.zsh/zfunc"
-set up an autaload clause appropriately.
-% { . ~/.zsh/zfunc/opp-install; opp-install }
-% autoload opp
 
-Note:
-This script replaces below vicmd key map entries.
-  ~, c, d, gu, gU and y
-Please beware of.
+1. source this file.
 
-Extension:
+        % source opp.zsh
 
-opp/textobj-between.zsh
-http://d.hatena.ne.jp/thinca/20100614/1276448745
-http://d.hatena.ne.jp/tarao/20100715/1279185753
+2. If you wish to load the extensions, source them afterward.
+
+        % source opp/*.zsh
+
+*Optionally* you can use the zcompiled file with the autoloading for a little faster loading on every shell startup, if you zcompile the necessary functions.
+
+1. Prepare zcompiling the defined functions and the install command.
+
+        % OS=(~/path/to/opp.zsh/{opp.zsh,opp/*.zsh})
+
+2. If you have some `opp/surround.zsh`’s configurations, those configurations could be zcompiled at this point. Assuming you have such a configuration file in `~/.zsh/opp-surround.zsh`, you could do this.
+
+        % OS=(~/path/to/opp.zsh/{opp.zsh,opp/*.zsh} ~/.zsh/opp-surround.zsh(N))
+
+3. Generate the `~/.zsh/zfunc/{opp,opp-install}.zwc`.
+
+        % (zsh -c "for O in $OS;do . $O;done && opp-zcompile $OS[1] ~/.zsh/zfunc"
+
+   Set up an autoload clause appropriately.
+
+        % { . ~/.zsh/zfunc/opp-install; opp-install }
+        % autoload opp
+
+**Note:** This script replaces the following vicmd key map entries: `~`, `c`, `d`, `gu`, `gU` and `y`. Please be aware of that.
+
+### Extensions
+
+#### `opp/textobj-between.zsh`
+
+* http://d.hatena.ne.jp/thinca/20100614/1276448745
+* http://d.hatena.ne.jp/tarao/20100715/1279185753
+
 Thank you very much, thinca and tarao!
 
-opp/surround.zsh
+#### `opp/surround.zsh`
+
 Thank you very much tpope!
-http://www.vim.org/scripts/script.php?script_id=1697
 
-TODO: in case these (ci" with improper double quotes) situations.
-TODO: operator (currently ~, c, d, gu, gU and y)
-TODO: o_v o_V o_CTRL_V
-TODO: as is op ip at it
+* [Tim Pope’s surround.vim](http://www.vim.org/scripts/script.php?script_id=1697)
 
-History
+### TODOs
 
-v0.0.7
-Add ~, gu and gU.
-Paren-matching operation fixes.
+* TODO: in case these (`ci"` with improper double quotes) situations.
+* TODO: operator (currently `~`, `c`, `d`, `gu`, `gU` and `y`)
+* TODO: `o_v` `o_V` `o_CTRL_V`
+* TODO: `as` `is` `op` `ip` `at` `it`
 
-v0.0.6
-Add opp/surround.zsh
+### History
 
-v0.0.5
-Add opp/textobj-between.zsh
-Add `opp-installer-add' for the extensions.
-Add aw aW iW and fix iw.
+#### v0.0.7
+* Add `~`, `gu` and `gU`.
+* Paren-matching operation fixes.
 
-v0.0.4
+#### v0.0.6
+* Add `opp/surround.zsh`
+
+#### v0.0.5
+* Add `opp/textobj-between.zsh`
+* Add `opp-installer-add` for the extensions.
+* Add `aw` `aW` `iW` and fix `iw`.
+
+#### v0.0.4
 Add textobj-between link.
 
-v0.0.3
-Cleanup inbetween codes.
+#### v0.0.3
+* Cleanup inbetween code.
 
-v0.0.2
-Fix cc dd yy not work bug.
+#### v0.0.2
+* Fix `cc` `dd` `yy` not work bug.
 
-v0.0.1
-Initial version.
-</pre>
+#### v0.0.1
+* Initial version.


### PR DESCRIPTION
This makes [`README.md`](https://github.com/hchbaw/opp.zsh/blob/master/README.md) use more of the features of Markdown so that it will be easier to read on https://github.com/hchbaw/opp.zsh. I also fix some grammar and capitalization errors.

You will probably need to also edit the comment at the top of [`opp.zsh`](https://github.com/hchbaw/opp.zsh/blob/master/opp.zsh) so it matches this README.

View the rendered version of this README as it will look on GitHub [here](https://github.com/roryokane/opp.zsh/blob/7d1498e196f03d4a8d1b9d51db7e46add488caf8/README.md).
